### PR TITLE
Fix Issue #36. Add BinanceExchange.symbols_info

### DIFF
--- a/ExchangeInterfaces/BitmexTest.py
+++ b/ExchangeInterfaces/BitmexTest.py
@@ -3,3 +3,4 @@ from ExchangeInterfaces.BitmexExchange import BitmexExchange
 
 class BitmexTest(BitmexExchange):
     ENDPOINT = "https://testnet.bitmex.com/api/v1"
+    TEST = True

--- a/ExchangeInterfaces/Exchange.py
+++ b/ExchangeInterfaces/Exchange.py
@@ -17,7 +17,7 @@ class Exchange(ABC):
         self.ids = []  # store here order which was created by program
         self.logger = logging.getLogger('cct')
 
-    def get_balance(self):
+    def get_balance(self) -> float:
         return self.balance
 
     def get_trading_symbols(self):

--- a/ExchangeInterfaces/Exchange.py
+++ b/ExchangeInterfaces/Exchange.py
@@ -20,13 +20,7 @@ class Exchange(ABC):
     def get_balance(self) -> float:
         return self.balance
 
-    def get_trading_symbols(self):
-        symbols = set()
-        for pair in self.pairs:
-            pair = str(pair)
-            symbols.add(pair[:3])
-            symbols.add(pair[3:])
-        return symbols
+
 
     @abstractmethod
     def stop(self):


### PR DESCRIPTION
- Fix wrong calculation in BitmexExchange.py --> Store balance in USD
- Fix Issue #36. The problem was in splitting base and quote asset.
- Add` BinanceExchange.symbols_info` to split base and quote asset.
- `BinanceExchange.balance` now dicitionary type for more comfortable using. 
